### PR TITLE
Web browser url encoding

### DIFF
--- a/CocoaExtensions/Categories/Foundation/NSString+Extensions.h
+++ b/CocoaExtensions/Categories/Foundation/NSString+Extensions.h
@@ -24,6 +24,6 @@
 
 + (NSString*)blankDefault:(id)value;
 
-+ (NSString *)encodeUrlString:(NSStringEncoding)encoding;
+- (NSString *)encodeUrlString:(NSStringEncoding)encoding;
 
 @end

--- a/CocoaExtensions/Categories/Foundation/NSString+Extensions.h
+++ b/CocoaExtensions/Categories/Foundation/NSString+Extensions.h
@@ -24,4 +24,6 @@
 
 + (NSString*)blankDefault:(id)value;
 
++ (NSString *)encodeUrlString:(NSStringEncoding)encoding;
+
 @end

--- a/CocoaExtensions/Categories/Foundation/NSString+Extensions.h
+++ b/CocoaExtensions/Categories/Foundation/NSString+Extensions.h
@@ -24,6 +24,6 @@
 
 + (NSString*)blankDefault:(id)value;
 
-- (NSString *)encodeUrlString:(NSStringEncoding)encoding;
+- (NSString *)urlStringUsingEncoding:(NSStringEncoding)encoding;
 
 @end

--- a/CocoaExtensions/Categories/Foundation/NSString+Extensions.m
+++ b/CocoaExtensions/Categories/Foundation/NSString+Extensions.m
@@ -65,7 +65,7 @@
   return [value isKindOfClass:[NSString class]] ? value : @"";
 }
 
-- (NSString *)encodeUrlString:(NSStringEncoding)encoding {
+- (NSString *)urlStringUsingEncoding:(NSStringEncoding)encoding {
   NSString *charactersToLeaveUnescaped = @"!*'\"();:@&=+$,/?%#[]% ";
   return (NSString *) CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,
                                                                                 (CFStringRef) self,

--- a/CocoaExtensions/Categories/Foundation/NSString+Extensions.m
+++ b/CocoaExtensions/Categories/Foundation/NSString+Extensions.m
@@ -65,5 +65,13 @@
   return [value isKindOfClass:[NSString class]] ? value : @"";
 }
 
++ (NSString *)encodeUrlString:(NSStringEncoding)encoding {
+  NSString *charactersToLeaveUnescaped = @"!*'\"();:@&=+$,/?%#[]% ";
+  return (NSString *) CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,
+                                                                                (CFStringRef) self,
+                                                                                (CFStringRef) charactersToLeaveUnescaped,
+                                                                                NULL,
+                                                                                CFStringConvertNSStringEncodingToEncoding(encoding)));
+}
 
 @end

--- a/CocoaExtensions/Categories/Foundation/NSString+Extensions.m
+++ b/CocoaExtensions/Categories/Foundation/NSString+Extensions.m
@@ -65,7 +65,7 @@
   return [value isKindOfClass:[NSString class]] ? value : @"";
 }
 
-+ (NSString *)encodeUrlString:(NSStringEncoding)encoding {
+- (NSString *)encodeUrlString:(NSStringEncoding)encoding {
   NSString *charactersToLeaveUnescaped = @"!*'\"();:@&=+$,/?%#[]% ";
   return (NSString *) CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,
                                                                                 (CFStringRef) self,

--- a/CocoaExtensions/Controllers/PPWebBrowserViewController.m
+++ b/CocoaExtensions/Controllers/PPWebBrowserViewController.m
@@ -33,7 +33,7 @@
 
 - (id)initWebViewControllerWithURLString:(NSString *)_urlString {
   if (self = [super init]) {
-    _urlString = [_urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    _urlString = [_urlString encodeUrlString:NSUTF8StringEncoding];
     if ([_urlString hasPrefix:@"http://"] || [_urlString hasPrefix:@"https://"]) {
       self.urlString = _urlString;
     } else {

--- a/CocoaExtensions/Controllers/PPWebBrowserViewController.m
+++ b/CocoaExtensions/Controllers/PPWebBrowserViewController.m
@@ -33,7 +33,7 @@
 
 - (id)initWebViewControllerWithURLString:(NSString *)_urlString {
   if (self = [super init]) {
-    _urlString = [_urlString encodeUrlString:NSUTF8StringEncoding];
+    _urlString = [_urlString urlStringUsingEncoding:NSUTF8StringEncoding];
     if ([_urlString hasPrefix:@"http://"] || [_urlString hasPrefix:@"https://"]) {
       self.urlString = _urlString;
     } else {


### PR DESCRIPTION
- defined explicitly characters which should leave unescaped for an url string
